### PR TITLE
update influxdb max-size

### DIFF
--- a/k8s/env-secret-config_template.yaml
+++ b/k8s/env-secret-config_template.yaml
@@ -15,6 +15,7 @@ data:
   kubernetes-pull-image-secret-name: "ci-tno-dots"
   simulator-name: "dots-so"
   log-level: "INFO"
+  influxdb-http-max-body-size: "0"
 
 ---
 apiVersion: v1

--- a/k8s/env-secret-config_template_old.yaml
+++ b/k8s/env-secret-config_template_old.yaml
@@ -15,6 +15,7 @@ data:
   kubernetes-pull-image-secret-name: "ci-tno-dots"
   simulator-name: "dots-so"
   log-level: "INFO"
+  influxdb-http-max-body-size: "0"
 
 ---
 apiVersion: v1

--- a/k8s/influxdb-deployment.yaml
+++ b/k8s/influxdb-deployment.yaml
@@ -24,6 +24,12 @@ spec:
         volumeMounts:
           - mountPath: /var/lib/influxdb
             name: influxdb-claim
+        env:
+        - name: INFLUXDB_HTTP_MAX_BODY_SIZE
+          valueFrom:
+            configMapKeyRef:
+              name: env-configmap
+              key: influxdb-http-max-body-size
       volumes:
         - name: influxdb-claim
           persistentVolumeClaim:


### PR DESCRIPTION
some data points were getting to big to write to influxdb in one go hence removing the http limit of writing 